### PR TITLE
Store documents by id

### DIFF
--- a/Tests/SVDBTests/CollectionTests.swift
+++ b/Tests/SVDBTests/CollectionTests.swift
@@ -33,6 +33,21 @@ class SVDBCollectionTests: XCTestCase {
         XCTAssertEqual(results.first?.text, text)
     }
 
+    func testAddDocument_Duplicate() {
+        let collection = Collection(name: "test")
+        let id = UUID()
+        let text = "Test text awesome 2"
+        let expected = "Test text we expect"
+        let embedding = [1.0, 2.0, 3.0]
+
+        collection.addDocument(id: id, text: text, embedding: embedding)
+        collection.addDocument(id: id, text: expected, embedding: embedding)
+
+        let results = collection.search(query: embedding, num_results: 5)
+        XCTAssertEqual(results.count, 1, "Documents with duplicate ids should be overwritten")
+        XCTAssertEqual(results.first?.text, expected)
+    }
+
     func testAddDocument_WithoutProvidedID() {
         let collection = Collection(name: "test")
         let text = "Test text Awesome"
@@ -74,5 +89,22 @@ class SVDBCollectionTests: XCTestCase {
         XCTAssertTrue(resultTexts.contains(document1.text))
         XCTAssertTrue(resultTexts.contains(document2.text))
         XCTAssertTrue(resultTexts.count == 2)
+    }
+
+    func testRemoveDocument_Existing() {
+        let collection = Collection(name: "test")
+        let id1 = UUID()
+        let id2 = UUID()
+        let document1 = Document(id: id1, text: "test1", embedding: [1.0, 2.0, 3.0])
+        let document2 = Document(id: id2, text: "test2", embedding: [4.0, 5.0, 6.0])
+
+        collection.addDocuments([document1, document2])
+        XCTAssertFalse(collection.search(query: []).isEmpty, "There should be a hit for this query")
+
+        collection.removeDocument(byId: id1)
+        XCTAssertEqual(collection.search(query: []).count, 1)
+
+        collection.removeDocument(byId: id2)
+        XCTAssertEqual(collection.search(query: []).count, 0)
     }
 }


### PR DESCRIPTION
Hi 👋 

I noticed that while documents have an id, they are not enforced to be unique. This can be surprising especially when removing by id, where duplicates could remain in the collection.

This PR changes how documents are stored in the collection, and enforces ids to be unique.

## Notes
- The document format is changed, which makes it a breaking change
I think it would be worthwhile to modify the collection to allow for different storage options in the future.

- This is not thread safe code
I would be happy to open a PR with thread safety added to the collection types